### PR TITLE
Add Notion page creation error handling

### DIFF
--- a/notion_image_uploader.py
+++ b/notion_image_uploader.py
@@ -87,10 +87,13 @@ def enviar_cervezas_a_notion(datos, lugar):
             },
         }
 
-        notion.pages.create(
-            parent={"database_id": NOTION_DATABASE_ID},
-            properties=propiedades
-        )
+        try:
+            notion.pages.create(
+                parent={"database_id": NOTION_DATABASE_ID},
+                properties=propiedades
+            )
+        except Exception as e:
+            raise Exception(f"Error al crear la página en Notion: {e}")
 
 if __name__ == "__main__":
     if len(sys.argv) != 3:
@@ -100,5 +103,8 @@ if __name__ == "__main__":
     ruta_img = sys.argv[1]
     lugar = sys.argv[2]
     datos = analizar_imagen_cerveza(ruta_img)
-    enviar_cervezas_a_notion(datos, lugar)
-    print("Imagen procesada y enviada a Notion con éxito.")
+    try:
+        enviar_cervezas_a_notion(datos, lugar)
+        print("Imagen procesada y enviada a Notion con éxito.")
+    except Exception as e:
+        print(f"Error al enviar la información a Notion: {e}")


### PR DESCRIPTION
## Summary
- add try/except around `notion.pages.create` to surface errors
- display friendly message when CLI upload fails

## Testing
- `python -m py_compile notion_image_uploader.py bot_uploader.py`


------
https://chatgpt.com/codex/tasks/task_e_684b6844845c8321b4b152bc1c012da7